### PR TITLE
Add more 🐋

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7
+FROM python:3.12.7 AS base
 
 WORKDIR /app
 
@@ -15,9 +15,29 @@ COPY ./requirements.txt .
 COPY ./requirements-dev.txt .
 RUN pip install -r requirements-dev.txt
 
+
+FROM base AS collectstatic
+COPY . .
+RUN DJANGO_STATIC_ROOT=/static python manage.py collectstatic --no-input
+RUN find /static -ls
+
+FROM ghcr.io/static-web-server/static-web-server:2.33.1 AS static-server
+WORKDIR /srv/http
+ENV SERVER_ROOT=/srv/http
+
+COPY --from=collectstatic /static /srv/http/static
+
+
+FROM base AS dev
+ENV RUN_MODE=dev
+
+
+FROM base AS server
+ENV RUN_MODE=prod
+
 COPY ./entrypoint.sh .
 
 COPY . .
 
-ENTRYPOINT [ "/app/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -2,3 +2,8 @@
 /registration-frontend-react
 
 .env
+/docker-compose.yaml
+/compose.yaml
+/Dockerfile
+/Dockerfile.dockerignore
+/*.sqlite3

--- a/config/settings.py
+++ b/config/settings.py
@@ -40,6 +40,7 @@ ALLOWED_HOSTS = os.getenv("DJANGO_HOSTS", "").split(",")
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -79,6 +80,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
+ASGI_APPLICATION = "config.asgi.application"
 
 
 # Database
@@ -131,6 +133,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = os.getenv("DJANGO_STATIC_ROOT")
 
 
 # Default primary key field type

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,22 +1,151 @@
 services:
-  web:
-    build: ./
-    command: python manage.py runserver 0.0.0.0:8000
-    volumes:
-      - .:/usr/src/Registrering
-    ports:
-      - "8000:8000"
-    env_file: .env
+  django:
+    build:
+      context: .
+      target: server
+      pull: true
+    pull_policy: build
+    #volumes:
+    #  - django_media:/app/media:rw
+
+    command: daphne config.asgi:application -b 0.0.0.0
+
     depends_on:
       - database
+    profiles:
+      - prod
+    env_file:
+      - .env
+    environment:
+      REGISTRATION_HOSTNAME: ${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.registration-backend.rule=Host(`${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}`) && PathRegexp(`^/(api|admin)`)
+      - traefik.http.services.registration-backend.loadbalancer.server.port=8000
+      #- traefik.http.routers.registration-backend.entrypoints=web,websecure
+
+  django-staticfiles:
+    build:
+      context: .
+      target: static-server
+      pull: true
+    pull_policy: build
+
+    # TODO: Set up Django media dir
+    #       Do we need this?
+    #       I'm not sure if it is needed yet; low pri backlog
+    #volumes:
+    #  - django_media:/srv/http/media:ro
+    profiles:
+      - prod
+    env_file:
+      - .env
+    environment:
+      REGISTRATION_HOSTNAME: ${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}
+      SERVER_LOG_LEVEL: warn
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.registration-backend-staticfiles.rule=Host(`${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}`) && PathRegexp(`^/(static)`)
+      - traefik.http.services.registration-backend-staticfiles.loadbalancer.server.port=80
+      #- traefik.http.routers.registration-backend-staticfiles.entrypoints=web,websecure
+
+  django-dev:
+    build:
+      context: .
+      target: dev
+      pull: true
+    pull_policy: build
+
+    command: python manage.py runserver 0.0.0.0:8000
+
+    volumes:
+      - .:/app:rw
+
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    depends_on:
+      - database
+    profiles:
+      - dev
+    environment:
+      REGISTRATION_HOSTNAME: ${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.registration-backend.rule=Host(`${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}`) && PathRegexp(`^/(api|admin|static)`)
+      #- traefik.http.routers.registration-backend.entrypoints=web,websecure
+
   database:
     image: postgres:17
-    env_file: .env
+    env_file:
+      - .env
     shm_size: 256MB
     volumes:
       - postgres_data:/var/lib/postgresql/data/
+    profiles:
+      - prod
+      - dev
+
+  nextjs:
+    build:
+      context: ./registration-frontend-react/
+      target: static-server
+      pull: true
+    pull_policy: build
+
+    profiles:
+      - prod
+    environment:
+      REGISTRATION_HOSTNAME: ${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.registration-frontend.rule=Host(`${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}`)
+      - traefik.http.services.registration-frontend.loadbalancer.server.port=80
+      #- traefik.http.routers.registration-frontend.entrypoints=web,websecure
+
+  nextjs-dev:
+    build:
+      context: ./registration-frontend-react/
+      target: dev-server
+      pull: true
+    pull_policy: build
+
+    volumes:
+      - ./registration-frontend-react:/app:rw
+    ports:
+      - 3000:3000/tcp
+    profiles:
+      - dev
+    environment:
+      REGISTRATION_HOSTNAME: ${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.registration-frontend.rule=Host(`${REGISTRATION_HOSTNAME:-registration.eventaccess.localhost}`)
+      #- traefik.http.routers.registration-frontend.entrypoints=web,websecure
+
+  reverse-proxy:
+    image: traefik:v3.2.0
+    pull_policy: always
+    command:
+      - --api.insecure=true
+      - --providers.docker
+      - --entryPoints.web.address=:80
+      #- --entryPoints.websecure.address=:443
+      - --providers.docker.exposedbydefault=false
+    ports:
+      - 80:80/tcp
+      # TODO: Add https configuration
+      #- 443:443/tcp
+      # The Web UI (enabled by --api.insecure=true)
+      - 8080:8080
+    profiles:
+      - dev
+      - prod
+    volumes:
+      # So that Traefik can listen to the Docker events
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   postgres_data:
-
-
+  #django_media:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,7 @@ fi
 
 python manage.py migrate
 
+python manage.py check --deploy
+
 exec "$@"
 

--- a/registration-frontend-react/Dockerfile
+++ b/registration-frontend-react/Dockerfile
@@ -1,0 +1,40 @@
+FROM node:22-bookworm AS base
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+ENV NEXT_TELEMETRY_DISABLED 1
+
+# Install dependencies only when needed
+FROM base AS deps
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM base AS dev-server
+WORKDIR /app
+VOLUME /app
+
+CMD npm install && npm run dev
+
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+
+RUN npm run build
+
+FROM ghcr.io/static-web-server/static-web-server:2.33.1 AS static-server
+
+WORKDIR /srv/http
+ENV SERVER_ROOT=/srv/http
+
+#COPY --from=builder /app/public ./public
+
+# https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
+COPY --from=builder /app/out ./
+

--- a/registration-frontend-react/next.config.ts
+++ b/registration-frontend-react/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
 	/* config options here */
+	output: 'export',
 };
 
 export default nextConfig;

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework==3.15.2
 django-browser-reload==1.17.0
 python-dotenv==1.0.1
 psycopg2-binary==2.9.10
+daphne==4.1.2


### PR DESCRIPTION
With this change, use one of the following for your docker compose commands;

`docker compose --profile dev up -d`
`docker compose --profile prod up -d`

The difference being the use of docker compose profiles.

`prod` profile is the beginning of the production setup, and `dev` launches the developement servers which should auto-refresh on changed files, without the need for re-running docker builds.