### PR TITLE
Fix package lock

### DIFF
--- a/registration-frontend-react/package-lock.json
+++ b/registration-frontend-react/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"next": "15.0.3",
-				"react": "19.0.0-rc-66855b96-20241106",
-				"react-dom": "19.0.0-rc-66855b96-20241106"
+				"react": "^19.0.0-0",
+				"react-dom": "^19.0.0-0"
 			},
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.1.0",

--- a/registration-frontend-react/package-lock.json
+++ b/registration-frontend-react/package-lock.json
@@ -8,9 +8,9 @@
 			"name": "registration-frontend-react",
 			"version": "0.1.0",
 			"dependencies": {
-				"next": "15.0.2",
-				"react": "19.0.0-rc-02c0e824-20241028",
-				"react-dom": "19.0.0-rc-02c0e824-20241028"
+				"next": "15.0.3",
+				"react": "19.0.0-rc-66855b96-20241106",
+				"react-dom": "19.0.0-rc-66855b96-20241106"
 			},
 			"devDependencies": {
 				"@eslint/eslintrc": "^3.1.0",
@@ -19,7 +19,7 @@
 				"@types/react": "^18",
 				"@types/react-dom": "^18",
 				"eslint": "9.15.0",
-				"eslint-config-next": "15.0.2",
+				"eslint-config-next": "15.0.3",
 				"postcss": "^8",
 				"tailwindcss": "^3.4.1",
 				"typescript": "^5"
@@ -676,15 +676,15 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.0.2.tgz",
-			"integrity": "sha512-c0Zr0ModK5OX7D4ZV8Jt/wqoXtitLNPwUfG9zElCZztdaZyNVnN40rDXVZ/+FGuR4CcNV5AEfM6N8f+Ener7Dg==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.0.3.tgz",
+			"integrity": "sha512-t9Xy32pjNOvVn2AS+Utt6VmyrshbpfUMhIjFO60gI58deSo/KgLOp31XZ4O+kY/Is8WAGYwA5gR7kOb1eORDBA==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.2.tgz",
-			"integrity": "sha512-R9Jc7T6Ge0txjmqpPwqD8vx6onQjynO9JT73ArCYiYPvSrwYXepH/UY/WdKDY8JPWJl72sAE4iGMHPeQ5xdEWg==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.3.tgz",
+			"integrity": "sha512-3Ln/nHq2V+v8uIaxCR6YfYo7ceRgZNXfTd3yW1ukTaFbO+/I8jNakrjYWODvG9BuR2v5kgVtH/C8r0i11quOgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -692,9 +692,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.0.2.tgz",
-			"integrity": "sha512-GK+8w88z+AFlmt+ondytZo2xpwlfAR8U6CRwXancHImh6EdGfHMIrTSCcx5sOSBei00GyLVL0ioo1JLKTfprgg==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.0.3.tgz",
+			"integrity": "sha512-s3Q/NOorCsLYdCKvQlWU+a+GeAd3C8Rb3L1YnetsgwXzhc3UTWrtQpB/3eCjFOdGUj5QmXfRak12uocd1ZiiQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -708,9 +708,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.0.2.tgz",
-			"integrity": "sha512-KUpBVxIbjzFiUZhiLIpJiBoelqzQtVZbdNNsehhUn36e2YzKHphnK8eTUW1s/4aPy5kH/UTid8IuVbaOpedhpw==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.0.3.tgz",
+			"integrity": "sha512-Zxl/TwyXVZPCFSf0u2BNj5sE0F2uR6iSKxWpq4Wlk/Sv9Ob6YCKByQTkV2y6BCic+fkabp9190hyrDdPA/dNrw==",
 			"cpu": [
 				"x64"
 			],
@@ -724,9 +724,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.0.2.tgz",
-			"integrity": "sha512-9J7TPEcHNAZvwxXRzOtiUvwtTD+fmuY0l7RErf8Yyc7kMpE47MIQakl+3jecmkhOoIyi/Rp+ddq7j4wG6JDskQ==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.0.3.tgz",
+			"integrity": "sha512-T5+gg2EwpsY3OoaLxUIofmMb7ohAUlcNZW0fPQ6YAutaWJaxt1Z1h+8zdl4FRIOr5ABAAhXtBcpkZNwUcKI2fw==",
 			"cpu": [
 				"arm64"
 			],
@@ -740,9 +740,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.0.2.tgz",
-			"integrity": "sha512-BjH4ZSzJIoTTZRh6rG+a/Ry4SW0HlizcPorqNBixBWc3wtQtj4Sn9FnRZe22QqrPnzoaW0ctvSz4FaH4eGKMww==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.0.3.tgz",
+			"integrity": "sha512-WkAk6R60mwDjH4lG/JBpb2xHl2/0Vj0ZRu1TIzWuOYfQ9tt9NFsIinI1Epma77JVgy81F32X/AeD+B2cBu/YQA==",
 			"cpu": [
 				"arm64"
 			],
@@ -756,9 +756,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.0.2.tgz",
-			"integrity": "sha512-i3U2TcHgo26sIhcwX/Rshz6avM6nizrZPvrDVDY1bXcLH1ndjbO8zuC7RoHp0NSK7wjJMPYzm7NYL1ksSKFreA==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.0.3.tgz",
+			"integrity": "sha512-gWL/Cta1aPVqIGgDb6nxkqy06DkwJ9gAnKORdHWX1QBbSZZB+biFYPFti8aKIQL7otCE1pjyPaXpFzGeG2OS2w==",
 			"cpu": [
 				"x64"
 			],
@@ -772,9 +772,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.0.2.tgz",
-			"integrity": "sha512-AMfZfSVOIR8fa+TXlAooByEF4OB00wqnms1sJ1v+iu8ivwvtPvnkwdzzFMpsK5jA2S9oNeeQ04egIWVb4QWmtQ==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.0.3.tgz",
+			"integrity": "sha512-QQEMwFd8r7C0GxQS62Zcdy6GKx999I/rTO2ubdXEe+MlZk9ZiinsrjwoiBL5/57tfyjikgh6GOU2WRQVUej3UA==",
 			"cpu": [
 				"x64"
 			],
@@ -788,9 +788,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.0.2.tgz",
-			"integrity": "sha512-JkXysDT0/hEY47O+Hvs8PbZAeiCQVxKfGtr4GUpNAhlG2E0Mkjibuo8ryGD29Qb5a3IOnKYNoZlh/MyKd2Nbww==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.0.3.tgz",
+			"integrity": "sha512-9TEp47AAd/ms9fPNgtgnT7F3M1Hf7koIYYWCMQ9neOwjbVWJsHZxrFbI3iEDJ8rf1TDGpmHbKxXf2IFpAvheIQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -804,9 +804,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.0.2.tgz",
-			"integrity": "sha512-foaUL0NqJY/dX0Pi/UcZm5zsmSk5MtP/gxx3xOPyREkMFN+CTjctPfu3QaqrQHinaKdPnMWPJDKt4VjDfTBe/Q==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.0.3.tgz",
+			"integrity": "sha512-VNAz+HN4OGgvZs6MOoVfnn41kBzT+M+tB+OK4cww6DNyWS6wKaDpaAm/qLeOUbnMh0oVx1+mg0uoYARF69dJyA==",
 			"cpu": [
 				"x64"
 			],
@@ -2211,13 +2211,13 @@
 			}
 		},
 		"node_modules/eslint-config-next": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.2.tgz",
-			"integrity": "sha512-N8o6cyUXzlMmQbdc2Kc83g1qomFi3ITqrAZfubipVKET2uR2mCStyGRcx/r8WiAIVMul2KfwRiCHBkTpBvGBmA==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.3.tgz",
+			"integrity": "sha512-IGP2DdQQrgjcr4mwFPve4DrCqo7CVVez1WoYY47XwKSrYO4hC0Dlb+iJA60i0YfICOzgNADIb8r28BpQ5Zs0wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@next/eslint-plugin-next": "15.0.2",
+				"@next/eslint-plugin-next": "15.0.3",
 				"@rushstack/eslint-patch": "^1.10.3",
 				"@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
 				"@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -3877,12 +3877,12 @@
 			"license": "MIT"
 		},
 		"node_modules/next": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.0.2.tgz",
-			"integrity": "sha512-rxIWHcAu4gGSDmwsELXacqAPUk+j8dV/A9cDF5fsiCMpkBDYkO2AEaL1dfD+nNmDiU6QMCFN8Q30VEKapT9UHQ==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/next/-/next-15.0.3.tgz",
+			"integrity": "sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.0.2",
+				"@next/env": "15.0.3",
 				"@swc/counter": "0.1.3",
 				"@swc/helpers": "0.5.13",
 				"busboy": "1.6.0",
@@ -3894,25 +3894,25 @@
 				"next": "dist/bin/next"
 			},
 			"engines": {
-				"node": ">=18.18.0"
+				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.0.2",
-				"@next/swc-darwin-x64": "15.0.2",
-				"@next/swc-linux-arm64-gnu": "15.0.2",
-				"@next/swc-linux-arm64-musl": "15.0.2",
-				"@next/swc-linux-x64-gnu": "15.0.2",
-				"@next/swc-linux-x64-musl": "15.0.2",
-				"@next/swc-win32-arm64-msvc": "15.0.2",
-				"@next/swc-win32-x64-msvc": "15.0.2",
+				"@next/swc-darwin-arm64": "15.0.3",
+				"@next/swc-darwin-x64": "15.0.3",
+				"@next/swc-linux-arm64-gnu": "15.0.3",
+				"@next/swc-linux-arm64-musl": "15.0.3",
+				"@next/swc-linux-x64-gnu": "15.0.3",
+				"@next/swc-linux-x64-musl": "15.0.3",
+				"@next/swc-win32-arm64-msvc": "15.0.3",
+				"@next/swc-win32-x64-msvc": "15.0.3",
 				"sharp": "^0.33.5"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
 				"@playwright/test": "^1.41.2",
 				"babel-plugin-react-compiler": "*",
-				"react": "^18.2.0 || 19.0.0-rc-02c0e824-20241028",
-				"react-dom": "^18.2.0 || 19.0.0-rc-02c0e824-20241028",
+				"react": "^18.2.0 || 19.0.0-rc-66855b96-20241106",
+				"react-dom": "^18.2.0 || 19.0.0-rc-66855b96-20241106",
 				"sass": "^1.3.0"
 			},
 			"peerDependenciesMeta": {
@@ -4477,24 +4477,24 @@
 			"license": "MIT"
 		},
 		"node_modules/react": {
-			"version": "19.0.0-rc-02c0e824-20241028",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-02c0e824-20241028.tgz",
-			"integrity": "sha512-GbZ7hpPHQMiEu53BqEaPQVM/4GG4hARo+mqEEnx4rYporDvNvUjutiAFxYFSbu6sgHwcr7LeFv8htEOwALVA2A==",
+			"version": "19.0.0-rc-66855b96-20241106",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-66855b96-20241106.tgz",
+			"integrity": "sha512-klH7xkT71SxRCx4hb1hly5FJB21Hz0ACyxbXYAECEqssUjtJeFUAaI2U1DgJAzkGEnvEm3DkxuBchMC/9K4ipg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.0.0-rc-02c0e824-20241028",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-02c0e824-20241028.tgz",
-			"integrity": "sha512-LrZf3DfHL6Fs07wwlUCHrzFTCMM19yA99MvJpfLokN4I2nBAZvREGZjZAn8VPiSfN72+i9j1eL4wB8gC695F3Q==",
+			"version": "19.0.0-rc-66855b96-20241106",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-66855b96-20241106.tgz",
+			"integrity": "sha512-D25vdaytZ1wFIRiwNU98NPQ/upS2P8Co4/oNoa02PzHbh8deWdepjm5qwZM/46OdSiGv4WSWwxP55RO9obqJEQ==",
 			"license": "MIT",
 			"dependencies": {
-				"scheduler": "0.25.0-rc-02c0e824-20241028"
+				"scheduler": "0.25.0-rc-66855b96-20241106"
 			},
 			"peerDependencies": {
-				"react": "19.0.0-rc-02c0e824-20241028"
+				"react": "19.0.0-rc-66855b96-20241106"
 			}
 		},
 		"node_modules/react-is": {
@@ -4679,9 +4679,9 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.25.0-rc-02c0e824-20241028",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-02c0e824-20241028.tgz",
-			"integrity": "sha512-GysnKjmMSaWcwsKTLzeJO0IhU3EyIiC0ivJKE6yDNLqt3IMxDByx8b6lSNXRNdN+ULUY0WLLjSPaZ0LuU/GnTg==",
+			"version": "0.25.0-rc-66855b96-20241106",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-66855b96-20241106.tgz",
+			"integrity": "sha512-HQXp/Mnp/MMRSXMQF7urNFla+gmtXW/Gr1KliuR0iboTit4KvZRY8KYaq5ccCTAOJiUqQh2rE2F3wgUekmgdlA==",
 			"license": "MIT"
 		},
 		"node_modules/semver": {

--- a/registration-frontend-react/package.json
+++ b/registration-frontend-react/package.json
@@ -13,8 +13,8 @@
 	},
 	"dependencies": {
 		"next": "15.0.3",
-		"react": "19.0.0-rc-66855b96-20241106",
-		"react-dom": "19.0.0-rc-66855b96-20241106"
+		"react": "^19.0.0-0",
+		"react-dom": "^19.0.0-0"
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.1.0",


### PR DESCRIPTION
Renovate PR didn't update the package lock file.

No functional difference between `19.0.0-rc-66855b96-20241106` and `^19.0.0-0`, because Nextjs specifies the exact version. The benefit is that there is no need to manually update package.json when Nextjs changes the version.